### PR TITLE
Add Alumni Spotlight Recommendation Form & General Cleanup

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,6 +1,5 @@
 {
   "projects": {
-    "staging": "mst-ka",
     "default": "mst-ka"
   },
   "targets": {
@@ -8,12 +7,6 @@
       "hosting": {
         "prod": [
           "mst-ka"
-        ],
-        "staging": [
-          "staging-mst-ka"
-        ],
-        "devel": [
-          "devel-mst-ka"
         ]
       }
     }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+database.rules.json

--- a/components/Home/Tour.js
+++ b/components/Home/Tour.js
@@ -23,7 +23,11 @@ function Tour() {
           <Typography variant="h4" sx={{ marginBottom: "1rem" }}>
             Kappa Alpha Order
           </Typography>
-          <Typography variant="body1" sx={{ fontStyle: "italic" }}>
+          <Typography
+            variant="body1"
+            align="justify"
+            sx={{ fontStyle: "italic" }}
+          >
             You come to college with your values intact; you&apos;ve learned
             from family and friends what&apos;s right and wrong. While in
             college, Kappa Alpha Order helps you keep your compass straight,
@@ -33,7 +37,7 @@ function Tour() {
             <br />
             <br />
           </Typography>
-          <Typography>
+          <Typography align="justify">
             <CheckIcon
               fontSize="medium"
               color="primary"
@@ -47,7 +51,7 @@ function Tour() {
             <br />
             <br />
           </Typography>
-          <Typography>
+          <Typography align="justify">
             <CheckIcon
               fontSize="medium"
               color="primary"
@@ -60,7 +64,7 @@ function Tour() {
             <br />
             <br />
           </Typography>
-          <Typography>
+          <Typography align="justify">
             <CheckIcon
               fontSize="medium"
               color="primary"
@@ -72,7 +76,7 @@ function Tour() {
             <br />
             <br />
           </Typography>
-          <Typography>
+          <Typography align="justify">
             <CheckIcon
               fontSize="medium"
               color="primary"
@@ -84,7 +88,14 @@ function Tour() {
             <br />
             <br />
           </Typography>
-          <Button variant="outlined" size="large" href="/about" endIcon={<ArrowRightIcon />}>Learn More</Button>
+          <Button
+            variant="outlined"
+            size="large"
+            href="/about"
+            endIcon={<ArrowRightIcon />}
+          >
+            Learn More
+          </Button>
         </Grid>
       </Grid>
     </>

--- a/components/Layout/Footer/Footer.js
+++ b/components/Layout/Footer/Footer.js
@@ -2,7 +2,7 @@ import { Box, Container, Divider, Grid, Link, Typography } from "@mui/material";
 import InstagramIcon from "@mui/icons-material/Instagram";
 import FacebookIcon from "@mui/icons-material/Facebook";
 import TwitterIcon from "@mui/icons-material/Twitter";
-import XIcon from '@mui/icons-material/X';
+import XIcon from "@mui/icons-material/X";
 import LinkedInIcon from "@mui/icons-material/LinkedIn";
 import GitHubIcon from "@mui/icons-material/GitHub";
 
@@ -24,7 +24,7 @@ const quickLinks = [
 
 function Footer() {
   return (
-    <Box sx={{}}>
+    <Box>
       <Container
         sx={{
           bgcolor: "#34363E",
@@ -63,9 +63,7 @@ function Footer() {
                 />
               </Link>
               <Link href="https://x.com/MST_KA">
-                <XIcon
-                  sx={{ color: "secondary.main", margin: ".5rem" }}
-                />
+                <XIcon sx={{ color: "secondary.main", margin: ".5rem" }} />
               </Link>
               <Link href="https://www.linkedin.com/company/beta-alpha-chapter-of-kappa-alpha-order/">
                 <LinkedInIcon
@@ -91,13 +89,24 @@ function Footer() {
               <br />
               1 Fraternity Drive Rolla, Missouri 65401
               <br />
-              <Typography sx={{ textDecoration: "underline" }}>
+              <Typography
+                component={"span"}
+                color="white.main"
+                sx={{ textDecoration: "underline" }}
+              >
                 President
               </Typography>
+              <br />
               {officerInfo.president.name}: {presidentPhoneNumber}
-              <Typography sx={{ textDecoration: "underline" }}>
+              <br />
+              <Typography
+                component={"span"}
+                color="white.main"
+                sx={{ textDecoration: "underline" }}
+              >
                 Alumnus Advisor
               </Typography>
+              <br />
               Jim Hennessey: {alumnusAdvisorPhoneNumber}
             </Typography>
           </Grid>

--- a/components/Layout/Layout.js
+++ b/components/Layout/Layout.js
@@ -5,6 +5,8 @@ import Footer from "./Footer/Footer";
 import { useRouter } from "next/router";
 import Safe from "react-safe";
 
+// Array of subpage pathnames we do not want to show the 'Apply for Membership' Button on
+const noApplyButtonSubpages = ["/apply", "/alumni", "/alumni/spotlight"];
 function Layout(props) {
   const router = useRouter();
   return (
@@ -35,7 +37,7 @@ function Layout(props) {
         {props.children}
       </Container>
       <Footer />
-      {router.pathname !== "/apply" && router.pathname !== "/alumni" && (
+      {!noApplyButtonSubpages.includes(router.pathname) && (
         <Fab
           variant="extended"
           color="primary"

--- a/components/Layout/Nav/MobileNavMenu.js
+++ b/components/Layout/Nav/MobileNavMenu.js
@@ -9,7 +9,12 @@ import PeopleIcon from "@mui/icons-material/People";
 import ContactPageIcon from "@mui/icons-material/ContactPage";
 
 import theme from "../../../utils/theme";
-import { valuesSubPages, awardsSubPages, aboutSubPages } from "../../../utils/subpages";
+import {
+  valuesSubPages,
+  awardsSubPages,
+  aboutSubPages,
+  alumniSubPages,
+} from "../../../utils/subpages";
 import MobileNavButton from "./MobileNavButton";
 import CollapsibleMobileNavButton from "./CollapsibleMobileNavButton";
 
@@ -21,8 +26,6 @@ const DrawerHeader = styled("div")(() => ({
   justifyContent: "flex-end",
   zIndex: -1,
 }));
-
-
 
 function MobileNavMenu(props) {
   return (
@@ -63,7 +66,11 @@ function MobileNavMenu(props) {
           title="About"
           subpages={aboutSubPages}
         />
-        <MobileNavButton link="/alumni" icon={<PeopleIcon />} title="Alumni" />
+        <CollapsibleMobileNavButton
+          icon={<PeopleIcon />}
+          title="Alumni"
+          subpages={alumniSubPages}
+        />
         <MobileNavButton
           link="/apply"
           icon={<ContactPageIcon />}

--- a/components/Layout/Nav/Navbar.js
+++ b/components/Layout/Nav/Navbar.js
@@ -12,6 +12,7 @@ import {
   valuesSubPages,
   awardsSubPages,
   aboutSubPages,
+  alumniSubPages,
 } from "../../../utils/subpages";
 import NavbarButton from "./NavbarButton";
 import MobileNavMenu from "./MobileNavMenu";
@@ -86,24 +87,23 @@ function Navbar() {
             {pages.map((page, index) => {
               if (page.title === "Values") {
                 subpageArray = valuesSubPages;
-              }
-              else if (page.title === "Awards"){
+              } else if (page.title === "Awards") {
                 subpageArray = awardsSubPages;
-              }
-              else if (page.title === "About Us"){
+              } else if (page.title === "About Us") {
                 subpageArray = aboutSubPages;
-              }
-              else{
+              } else if (page.title === "Alumni") {
+                subpageArray = alumniSubPages;
+              } else {
                 subpageArray = [];
               }
 
-              return(
+              return (
                 <NavbarButton
-                key={index}
-                title={page.title}
-                link={page.link}
-                subpages={subpageArray}
-              />
+                  key={index}
+                  title={page.title}
+                  link={page.link}
+                  subpages={subpageArray}
+                />
               );
             })}
           </Box>

--- a/database.rules.json
+++ b/database.rules.json
@@ -3,7 +3,7 @@
 		"newsletterEmailSignUp": {
 			".read": false,
 			"$signUpId": {
-				".write": "!data.exists() && newData.hasChildren(['firstName', 'lastName', 'pledgeClass', 'email'])",
+			".write": "!data.exists() && newData.hasChildren(['firstName', 'lastName', 'pledgeClass', 'email'])",
 				"email":       { ".validate": "newData.isString() && newData.val().length <= 320" },
 				"firstName":   { ".validate": "newData.isString() && newData.val().length <= 50"  },
 				"lastName":    { ".validate": "newData.isString() && newData.val().length <= 50"  },
@@ -13,7 +13,7 @@
 		"applications": {
 			".read": false,
 			"$applicationId": {
-				".write": "!data.exists() && newData.hasChildren(['firstName', 'lastName', 'phone', 'email', 'hometown', 'state', 'age', 'highSchool', 'classRank', 'gpa', 'actSAT', 'religion', 'intendedMajor', 'highSchoolActivities', 'honorsAwards', 'goals', 'contactWith', 'whyConsidering', 'likeAboutChapter', 'gentleman'])",
+			".write": "!data.exists() && newData.hasChildren(['firstName', 'lastName', 'phone', 'email', 'hometown', 'state', 'age', 'highSchool', 'classRank', 'gpa', 'actSAT', 'religion', 'intendedMajor', 'highSchoolActivities', 'honorsAwards', 'goals', 'contactWith', 'whyConsidering', 'likeAboutChapter', 'gentleman'])",
 				"firstName": 		    { ".validate": "newData.isString()" },
 				"lastName":             { ".validate": "newData.isString()" },
 				"phone":                { ".validate": "newData.isString()" },
@@ -34,6 +34,19 @@
 				"whyConsidering":       { ".validate": "newData.isString()" },
 				"likeAboutChapter":     { ".validate": "newData.isString()" },
 				"gentleman":            { ".validate": "newData.isString()" }
+			}
+		},
+		"alumniSpotlight": {
+			".read": false,
+			"$spotlightId" : {
+			".write": "!data.exists() && newData.hasChildren(['yourFullName', 'yourPhoneNumber', 'yourEmail', 'recFullName', 'recPhoneNumber', 'recEmail', 'whyRecommended'])",
+			"yourFullName": 	{".validate": "newData.isString()"}, 
+			"yourPhoneNumber": 	{".validate": "newData.isString()"}, 
+			"yourEmail": 		{".validate": "newData.isString()"}, 
+			"recFullName": 		{".validate": "newData.isString()"}, 
+			"recPhoneNumber": 	{".validate": "newData.isString()"}, 
+			"recEmail": 		{".validate": "newData.isString()"}, 
+			"whyRecommended": 	{".validate": "newData.isString()"}
 			}
 		}
 	}

--- a/firebase.json
+++ b/firebase.json
@@ -10,30 +10,15 @@
         "Jared Hanisch <jared.hanisch@gmail.com>",
         "Mateusz Przezdziecki <madprzez@gmail.com>"
       ]
-    },
-    {
-      "target": "staging",
-      "public": "out",
-      "cleanUrls": true,
-      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
-      "contributors": [
-        "Joe Studer <joe.studer.18@gmail.com>",
-        "Jared Hanisch <jared.hanisch@gmail.com>",
-        "Mateusz Przezdziecki <madprzez@gmail.com>"
-      ]
-    },
-    {
-      "target": "devel",
-      "public": "out",
-      "cleanUrls": true,
-      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
-      "contributors": [
-        "Joe Studer <joe.studer.18@gmail.com>",
-        "Jared Hanisch <jared.hanisch@gmail.com>",
-        "Mateusz Przezdziecki <madprzez@gmail.com>"
-      ]
     }
   ],
+  "functions": {
+    "predeploy": ["npm --prefix \"$RESOURCE_DIR\" run lint"],
+    "source": "functions"
+  },
+  "database": {
+    "rules": "database.rules.json"
+  },
   "emulators": {
     "functions": {
       "port": 5001,
@@ -49,9 +34,5 @@
     "ui": {
       "enabled": true
     }
-  },
-  "functions": {
-    "predeploy": ["npm --prefix \"$RESOURCE_DIR\" run lint"],
-    "source": "functions"
   }
 }

--- a/functions/index.js
+++ b/functions/index.js
@@ -13,16 +13,6 @@ const constants = require("./constants");
 
 admin.initializeApp();
 
-const applicationContactEmails = [
-  "Joe Studer <joe.studer.18@gmail.com>",
-  "Jared Hanisch <jared.hanisch@gmail.com>",
-  "Christian Matoushek <christian.matoushek@gmail.com",
-  "twbyny@umsystem.edu", // Trey Brown       - President
-  "ceak3z@umsystem.edu", // Chris Altamirano - Corresponding Secretary
-  "bcdkcd@umsystem.edu", // Brady Dodd       - Recruitment Chairman
-  "pjb4kh@umsystem.edu", // Parker Bruns     - Recruitment Chairman
-];
-
 const email = (sender, receiver, message) => {
   const transporter = nodemailer.createTransport({
     service: "Zoho",
@@ -48,12 +38,21 @@ const email = (sender, receiver, message) => {
   });
 };
 
+const applicationContactEmails = [
+  // "Joe Studer <joe.studer.18@gmail.com>",
+  "Jared Hanisch <jared.hanisch@gmail.com>",
+  // "Christian Matoushek <christian.matoushek@gmail.com",
+  // "twbyny@umsystem.edu", // Trey Brown       - President
+  // "ceak3z@umsystem.edu", // Chris Altamirano - Corresponding Secretary
+  // "bcdkcd@umsystem.edu", // Brady Dodd       - Recruitment Chairman
+  // "pjb4kh@umsystem.edu", // Parker Bruns     - Recruitment Chairman
+];
+
 exports.onDataAddedApps = functions.database
   .ref("/applications/{sessionId}")
   .onCreate(function (snap) {
     //prettier-ignore
     const emailContent = {
-      ...snap.val(),
       subject: `[MST-KA Website]: Membership Application for ${snap.val().firstName} ${snap.val().lastName}`,
       message: `Name: ${snap.val().firstName} ${snap.val().lastName}<br/><br/>
                 Phone: ${snap.val().phone}<br/><br/>
@@ -87,6 +86,44 @@ exports.onDataAddedApps = functions.database
 
     // Suppress warning of returning "Function returned undefined, expected Promise or value"
     return 0;
+  });
+
+const alumniSpotlightContactEmails = [
+  // "Joe Studer <joe.studer.18@gmail.com>",
+  // "Jared Hanisch <jared.hanisch@gmail.com>",
+  // "Christian Matoushek <christian.matoushek@gmail.com",
+  "betaalphaalumni1903@gmail.com",
+];
+
+exports.onDataAddedSpotlight = functions.database
+  .ref("alumniSpotlight/{sessionId}")
+  .onCreate(function (snap) {
+    //prettier-ignore
+    const emailContent = {
+      subject: `[MST-KA Website] Alumni Spotlight Recommendation for ${snap.val().recFullName}`,
+      message: `Recommended By:<br/>
+                ${snap.val().yourFullName}<br/>
+                ${snap.val().yourPhoneNumber}<br/>
+                ${snap.val().yourEmail}<br/><br/>
+                Recommended Brother's Information:<br/>
+                ${snap.val().recFullName}<br/>
+                ${snap.val().recPhoneNumber}<br/>
+                ${snap.val().recEmail}<br/><br/>
+                Testimonial:<br/>
+                ${snap.val().whyRecommended}`
+    }
+
+    console.log(
+      `Sending Alumni Spotlight Recommendation for ${
+        snap.val().recFullName
+      } from ${snap.val().yourFullName}`
+    );
+
+    email(
+      functions.config().mail.login,
+      alumniSpotlightContactEmails,
+      emailContent
+    );
   });
 
 const addNewSubscriber = (header, bodyContent, url) =>

--- a/pages/about/academics.js
+++ b/pages/about/academics.js
@@ -9,7 +9,7 @@ function Academics() {
       <Container sx={{ padding: { mobile: "2rem", laptop: "2rem 20rem" } }}>
         <Grid container spacing={8}>
           <Grid item mobile={12} tablet={6}>
-            <Typography>
+            <Typography align="justify">
               Kappa Alpha Order recognizes that academic success is a key to
               long term success for both new and active members. Being a top
               achiever on campus, Kappa Alpha Order has derived habits and a

--- a/pages/about/greek-life.js
+++ b/pages/about/greek-life.js
@@ -9,7 +9,7 @@ function BAOfKAGreekLife() {
       <Container sx={{ padding: { mobile: "2rem", laptop: "2rem 20rem" } }}>
         <Grid container spacing={8}>
           <Grid item mobile={12} tablet={6}>
-            <Typography>
+            <Typography align="justify">
               In Kappa Alpha Order we strive for excellence in all aspects on
               campus, including socialization with others. We understand that
               college puts a lot of stress on you and that is why we look to

--- a/pages/about/index.js
+++ b/pages/about/index.js
@@ -11,7 +11,7 @@ function About() {
         <Grid container spacing={8}>
           <Grid item mobile={12} tablet={6}>
             <TextSectionHeading>Kappa Alpha Order History</TextSectionHeading>
-            <Typography>
+            <Typography align="justify">
               Kappa Alpha Order was founded by four men, bound their friendship
               in a “mutual pledge of faith and loyalty,” at Washington College
               in Virginia, in December of 1865.
@@ -32,7 +32,7 @@ function About() {
           />
           <Grid item mobile={12} tablet={6}>
             <TextSectionHeading>The Philosophy of the Order</TextSectionHeading>
-            <Typography>
+            <Typography align="justify">
               The acquisition of knowledge and the development of character are
               the great goals of life, and the primary focus for gentlemen of
               Kappa Alpha Order.
@@ -53,7 +53,7 @@ function About() {
             <TextSectionHeading>
               The Impacts of Fraternity Participation
             </TextSectionHeading>
-            <Typography>
+            <Typography align="justify">
               You can greatly enhance the rewards of college life through a
               fraternity experience. Transitioning to college life, students
               often search for a group -- somewhere they feel comfortable
@@ -86,7 +86,7 @@ function About() {
             <TextSectionHeading>
               A Moral Compass for the Modern Gentleman
             </TextSectionHeading>
-            <Typography>
+            <Typography align="justify">
               You come to college with your values intact; you&apos;ve learned
               from family and friends what&apos;s right and wrong.
               <br />
@@ -107,7 +107,7 @@ function About() {
             <TextSectionHeading>
               History of Beta Alpha Chapter
             </TextSectionHeading>
-            <Typography>
+            <Typography align="justify">
               The Beta Alpha Chapter of Kappa Alpha Order was founded on April
               27, 1903, making it the second oldest fraternity on campus
               <br />

--- a/pages/about/letter-from-ka-parent.js
+++ b/pages/about/letter-from-ka-parent.js
@@ -9,7 +9,7 @@ function LetterFromKAParent() {
       <Container sx={{ padding: { mobile: "2rem", laptop: "2rem 20rem" } }}>
         <Grid container spacing={8}>
           <Grid item mobile={12} tablet={6}>
-            <Typography>
+            <Typography align="justify">
               Greek Life offers an excellent opportunity for college students to
               enhance their classroom learning by developing their leadership
               and social skills so essential for success in life. We were very

--- a/pages/about/parents-faq.js
+++ b/pages/about/parents-faq.js
@@ -13,7 +13,7 @@ import Banner from "../../components/Layout/Banner/Banner";
 function ParentsFAQ() {
   return (
     <div>
-      <Banner text="Parents' Frequently Asked Questions "/>
+      <Banner text="Parents' Frequently Asked Questions " />
       <Container sx={{ padding: { mobile: "2rem", laptop: "2rem 20rem" } }}>
         For your son, making the transition from high school or community
         college to a four-year college or university may seem like an imposing
@@ -71,7 +71,7 @@ function ParentsFAQ() {
         <br />
         <br />
         As a parent, you are undoubtedly concerned about your son&apos;s college
-        experience and the choices he willmake. Below, we answer some of the
+        experience and the choices he will make. Below, we answer some of the
         questions you may have about fraternity membership.
         <br />
         <br />

--- a/pages/about/scholarships.js
+++ b/pages/about/scholarships.js
@@ -9,7 +9,7 @@ function Scholarships() {
       <Container sx={{ padding: { mobile: "2rem", laptop: "2rem 20rem" } }}>
         <Grid container spacing={8}>
           <Grid item mobile={12} tablet={6}>
-            <Typography>
+            <Typography align="justify">
               The Beta Alpha Education Foundation was established in April 2012
               as a 501(c)(3) public charity for the purpose of providing
               scholarships and granting money for educational related housing

--- a/pages/alumni/index.js
+++ b/pages/alumni/index.js
@@ -1,4 +1,4 @@
-import { Container, Divider, Grid, Typography } from "@mui/material";
+import { Container, Divider, Grid, Link, Typography } from "@mui/material";
 import Banner from "../../components/Layout/Banner/Banner";
 import Newsletter from "../../components/Subpages/Alumni/Newsletter";
 import MailingListSignup from "../../components/Subpages/Alumni/MailingListSignUp";
@@ -73,7 +73,7 @@ const newsletters = [
 function Alumni() {
   return (
     <div>
-      <Banner text="Alumni" />
+      <Banner text="The BAAA Journal" />
       <Container
         sx={{
           padding: {
@@ -83,14 +83,17 @@ function Alumni() {
           },
         }}
       >
-        <Typography sx={{ padding: "1rem" }}>
+        <Typography align="justify" sx={{ padding: "1rem" }}>
           Welcome to our alumni page where you will find our alumni newsletter,
           The BAAA Journal, organized by the Beta Alpha Alumni Association
           (BAAA). We release our newsletter bi-annually, highlighting: news,
           history, ways for alumni to get involved, and our brothers&apos; life
-          events &amp; accomplishments. If you have questions or suggestions for
-          future stories to be highlighted please reach out to one of the BAAA
-          Contacts on the last page of any issue of The BAAA Journal below!
+          events &amp; accomplishments. If you would like to recommend a brother
+          to be featured in a future issue of The BAAA Journal, please fill out{" "}
+          <Link href="/alumni/spotlight">this form</Link>. If you have questions
+          or suggestions for future stories to be highlighted please reach out
+          to one of the BAAA Contacts on the last page of any issue of The BAAA
+          Journal below!
         </Typography>
         <Divider sx={{ margin: "1rem 0rem" }} />
         <MailingListSignup />

--- a/pages/alumni/spotlight.js
+++ b/pages/alumni/spotlight.js
@@ -1,0 +1,290 @@
+import { useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Container,
+  Grid,
+  Link,
+  Snackbar,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { useFormik } from "formik";
+import * as yup from "yup";
+import { GoogleReCaptcha } from "react-google-recaptcha-v3";
+import { push, ref } from "firebase/database";
+import database from "../../firebase-init";
+import Banner from "../../components/Layout/Banner/Banner";
+import { scrollToErrors } from "../../utils/form-helpers.js";
+import DoubleArrowIcon from "@mui/icons-material/DoubleArrow";
+
+const alumniSpotlightValidationSchema = yup.object({
+  yourFullName: yup.string().required("Required"),
+  yourPhoneNumber: yup
+    .string()
+    .min(10, "Please enter full 10-digit phone number")
+    .max(15, "Phone number may not be greater than 15 digits")
+    .required("Required"),
+  yourEmail: yup
+    .string()
+    .email("Please enter a valid email")
+    .required("Required"),
+  recFullName: yup.string().required("Required"),
+  recPhoneNumber: yup
+    .string()
+    .min(10, "Please enter full 10-digit phone number")
+    .max(15, "Phone number may not be greater than 15 digits")
+    .required("Required"),
+  recEmail: yup
+    .string()
+    .email("Please enter a valid email")
+    .required("Required"),
+  whyRecommended: yup.string().required("Required"),
+});
+
+function AlumniSpotlight() {
+  const [recaptchaPassed, setRecaptchaPassed] = useState(false);
+  //Handler for enabling the submit button for the form once the ReCAPTCHA is successful
+  const handleRecaptcha = () => {
+    setRecaptchaPassed(true);
+  };
+
+  const [openSuccessSnackbar, setOpenSuccessSnackbar] = useState(false);
+  const handleCloseSuccessSnackbar = () => {
+    setOpenSuccessSnackbar(false);
+  };
+
+  const formik = useFormik({
+    initialValues: {
+      yourFullName: "",
+      yourPhoneNumber: "",
+      yourEmail: "",
+      recFullName: "",
+      recPhoneNumber: "",
+      recEmail: "",
+      whyRecommended: "",
+    },
+    validationSchema: alumniSpotlightValidationSchema,
+    onSubmit: (values, actions) => {
+      push(ref(database, "alumniSpotlight/"), {
+        yourFullName: values.yourFullName,
+        yourPhoneNumber: values.yourPhoneNumber,
+        yourEmail: values.yourEmail,
+        recFullName: values.recFullName,
+        recPhoneNumber: values.recPhoneNumber,
+        recEmail: values.recEmail,
+        whyRecommended: values.whyRecommended,
+      }).then(() => {
+        //Upon success
+        setOpenSuccessSnackbar(true);
+        actions.resetForm();
+      });
+    },
+  });
+
+  return (
+    <div>
+      <Banner text="Alumni Spotlight Recommendation" />
+      <form onSubmit={formik.handleSubmit}>
+        <Container
+          sx={{
+            padding: {
+              mobile: "2rem",
+              tablet: "2rem 12rem",
+              laptop: "2rem auto",
+            },
+          }}
+        >
+          <Typography align="justify">
+            We are thrilled to feature the achievements and stories of fellow
+            alumni in our upcoming <Link href="/alumni">BAAA Journals</Link>.
+            This is your opportunity to recommend a fellow brother whose
+            accomplishments and experiences would inspire and connect our
+            chapter. Your recommendations help us highlight the best of our
+            brotherhood, and we appreciate your input in shaping our spotlight
+            features.
+          </Typography>
+          <br />
+          <Typography align="justify">
+            We are seeking to highlight brothers whose stories reflect the
+            values and ideals of The Kappa Alpha Order. Please share why you
+            believe we should connect with this brother. For example, what
+            notable achievements, qualities, or experiences make him stand out?
+            Additionally, what topics should we be sure to cover in our
+            conversation with him? Whether it&apos;s his professional journey,
+            contributions to the community, mentorship, experiences, or how he
+            embodies the principles of Kappa Alpha, your insights will guide our
+            discussion and help us feature a well-rounded profile.
+          </Typography>
+          <Box sx={{ padding: "1rem 0rem" }}>
+            <Typography variant="h5">Your Information</Typography>
+            <Typography>
+              Providing your contact information allows us to follow up with you
+              if we need help connecting with your recommendation.
+            </Typography>
+          </Box>
+          <Grid container spacing={2}>
+            <Grid item mobile={12} tablet={4}>
+              <TextField
+                id="yourFullName"
+                fullWidth
+                label="Full Name"
+                required
+                {...formik.getFieldProps("yourFullName")}
+                error={
+                  formik.touched.yourFullName &&
+                  Boolean(formik.errors.yourFullName)
+                }
+                helperText={
+                  formik.touched.yourFullName && formik.errors.yourFullName
+                }
+              />
+            </Grid>
+            <Grid item mobile={12} tablet={4}>
+              <TextField
+                id="yourPhoneNumber"
+                fullWidth
+                label="Phone Number (XXXXXXXXXX)"
+                required
+                {...formik.getFieldProps("yourPhoneNumber")}
+                error={
+                  formik.touched.yourPhoneNumber &&
+                  Boolean(formik.errors.yourPhoneNumber)
+                }
+                helperText={
+                  formik.touched.yourPhoneNumber &&
+                  formik.errors.yourPhoneNumber
+                }
+              />
+            </Grid>
+            <Grid item mobile={12} tablet={4}>
+              <TextField
+                id="yourEmail"
+                fullWidth
+                label="Email"
+                required
+                {...formik.getFieldProps("yourEmail")}
+                error={
+                  formik.touched.yourEmail && Boolean(formik.errors.yourEmail)
+                }
+                helperText={formik.touched.yourEmail && formik.errors.yourEmail}
+              />
+            </Grid>
+          </Grid>
+          <Box sx={{ padding: "1rem 0rem" }}>
+            <Typography variant="h5">Recommended Brother</Typography>
+            <Typography>
+              Providing the contact information of the brother you are
+              recommending allows us to reach out directly to gather further
+              details for the Alumni Spotlight.
+            </Typography>
+          </Box>
+          <Grid container spacing={2}>
+            <Grid item mobile={12} tablet={4}>
+              <TextField
+                id="recFullName"
+                fullWidth
+                label="Full Name"
+                required
+                {...formik.getFieldProps("recFullName")}
+                error={
+                  formik.touched.recFullName &&
+                  Boolean(formik.errors.recFullName)
+                }
+                helperText={
+                  formik.touched.recFullName && formik.errors.recFullName
+                }
+              />
+            </Grid>
+            <Grid item mobile={12} tablet={4}>
+              <TextField
+                id="recPhoneNumber"
+                fullWidth
+                label="Phone Number (XXXXXXXXXX)"
+                required
+                {...formik.getFieldProps("recPhoneNumber")}
+                error={
+                  formik.touched.recPhoneNumber &&
+                  Boolean(formik.errors.recPhoneNumber)
+                }
+                helperText={
+                  formik.touched.recPhoneNumber && formik.errors.recPhoneNumber
+                }
+              />
+            </Grid>
+            <Grid item mobile={12} tablet={4}>
+              <TextField
+                id="recEmail"
+                fullWidth
+                label="Email"
+                required
+                {...formik.getFieldProps("recEmail")}
+                error={
+                  formik.touched.recEmail && Boolean(formik.errors.recEmail)
+                }
+                helperText={formik.touched.recEmail && formik.errors.recEmail}
+              />
+            </Grid>
+          </Grid>
+          <TextField
+            id="whyRecommended"
+            fullWidth
+            multiline
+            minRows={10}
+            label="Why should this brother be featured as an Alumni Spotlight?"
+            required
+            {...formik.getFieldProps("whyRecommended")}
+            error={
+              formik.touched.whyRecommended &&
+              Boolean(formik.errors.whyRecommended)
+            }
+            helperText={
+              formik.touched.whyRecommended && formik.errors.whyRecommended
+            }
+            sx={{ margin: "2rem 0rem" }}
+          ></TextField>
+          <GoogleReCaptcha onVerify={handleRecaptcha} />
+          <Button
+            type="submit"
+            variant="outlined"
+            size="large"
+            endIcon={<DoubleArrowIcon />}
+            onClick={() => {
+              scrollToErrors(formik.errors);
+            }}
+            sx={{ margin: "1rem 0rem" }}
+            disabled={
+              !recaptchaPassed || formik.isSubmitting || !formik.isValid
+            }
+          >
+            Submit
+          </Button>
+          <Typography color="#b9b9b9" variant="subtitle2">
+            This site is protected by reCAPTCHA and the Google{" "}
+            <Link href="https://policies.google.com/privacy">
+              Privacy Policy
+            </Link>{" "}
+            and{" "}
+            <Link href="https://policies.google.com/terms">
+              Terms of Service
+            </Link>{" "}
+            apply.
+          </Typography>
+          <Snackbar
+            anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+            open={openSuccessSnackbar}
+            autoHideDuration={6000}
+            onClose={handleCloseSuccessSnackbar}
+            sx={{ bottom: { mobile: "4rem" } }}
+          >
+            <Alert variant="filled" severity="success">
+              Thank you for your Alumni Spotlight recommendation!
+            </Alert>
+          </Snackbar>
+        </Container>
+      </form>
+    </div>
+  );
+}
+export default AlumniSpotlight;

--- a/pages/apply/index.js
+++ b/pages/apply/index.js
@@ -17,8 +17,9 @@ import { GoogleReCaptcha } from "react-google-recaptcha-v3";
 import { push, ref } from "firebase/database";
 import database from "../../firebase-init.js";
 import Banner from "../../components/Layout/Banner/Banner.js";
+import { scrollToErrors } from "../../utils/form-helpers.js";
 
-const validationSchema = yup.object({
+const membershipAppValidationSchema = yup.object({
   firstName: yup.string().required("Required"),
   lastName: yup.string().required("Required"),
   phone: yup
@@ -49,16 +50,6 @@ const validationSchema = yup.object({
   likeAboutChapter: yup.string().required("Required"),
   gentleman: yup.string().required("Required"),
 });
-
-//Click event handler for the Submit button to focus on fields that have errors associated with it
-const scrollToErrors = (errors) => {
-  const errorKeys = Object.keys(errors);
-  if (errorKeys.length > 0) {
-    setTimeout(() => {
-      document.getElementsByName(errorKeys[0])[0].focus();
-    }, 10);
-  }
-};
 
 //If we would like to display alternate helper text for our user prior to there being
 //errors associated with their input. See the Class Rank field for an example.
@@ -106,8 +97,8 @@ function Contact() {
       likeAboutChapter: "",
       gentleman: "",
     },
-    validationSchema: validationSchema,
-    onSubmit: (values, { resetForm }) => {
+    validationSchema: membershipAppValidationSchema,
+    onSubmit: (values, actions) => {
       // prettier-ignore
       if (window.confirm("Are you sure you would like to submit your application?")) {
         //push to Firebase Realtime Database
@@ -133,7 +124,7 @@ function Contact() {
           likeAboutChapter: values.likeAboutChapter,
           gentleman: values.gentleman,
         }).then(() => {
-          resetForm();
+          actions.resetForm();
           setOpenSnackbar(true);
         });
       }
@@ -146,7 +137,7 @@ function Contact() {
       <form onSubmit={formik.handleSubmit}>
         <Container sx={{ padding: { mobile: "2rem", laptop: "2rem 20rem" } }}>
           <br />
-          <Typography align="left">
+          <Typography align="justify">
             The brothers of the Beta Alpha Chapter of Kappa Alpha Order are
             determined to recruit men who will become contributing members to
             our brotherhood. This application is meant to help us get to know
@@ -487,7 +478,9 @@ function Contact() {
                   onClick={() => {
                     scrollToErrors(formik.errors);
                   }}
-                  disabled={!recaptchaPassed || formik.isSubmitting}
+                  disabled={
+                    !recaptchaPassed || formik.isSubmitting || !formik.isValid
+                  }
                 >
                   Submit Application
                 </Button>
@@ -513,6 +506,7 @@ function Contact() {
               open={openSnackbar}
               autoHideDuration={6000}
               onClose={handleCloseSnackbar}
+              sx={{ bottom: { mobile: "4rem" } }}
             >
               <Alert variant="filled" severity="success">
                 Application Successfully Submitted!

--- a/pages/awards/index.js
+++ b/pages/awards/index.js
@@ -9,7 +9,7 @@ function Awards() {
       <Container sx={{ padding: { mobile: "2rem", laptop: "2rem 20rem" } }}>
         <Grid container spacing={8}>
           <Grid item mobile={12} tablet={6}>
-            <Typography>
+            <Typography align="justify">
               Each February, KA chapters nationwide are recognized for their
               accomplishments throughout the year at regionally hosted Province
               Councils.

--- a/pages/awards/national-awards.js
+++ b/pages/awards/national-awards.js
@@ -13,7 +13,7 @@ function NationalAwards() {
             <TextSectionHeading>
               George C. Marshall Award for Chapter Excellence
             </TextSectionHeading>
-            <Typography>
+            <Typography align="justify">
               The George C. Marshall Award is given to the top 0-3 KA chapters
               nationally each year. Of the 45+ Marshalls awarded, our chapter
               holds 13 (as of 2022). This gives us the distinct honor of being
@@ -29,7 +29,7 @@ function NationalAwards() {
             <TextSectionHeading>
               Samuel Zenas Ammen Award for Chapter Excellence
             </TextSectionHeading>
-            <Typography>
+            <Typography align="justify">
               Similarly to the Marshall Award, the Samuel Zenas Ammen Award is
               awarded to the top 10% of KA chapters in the nation annually.
               <br />

--- a/pages/values/bond-of-brotherhood.js
+++ b/pages/values/bond-of-brotherhood.js
@@ -9,7 +9,7 @@ function BondOfBrotherhood() {
       <Container sx={{ padding: { mobile: "2rem", laptop: "2rem 20rem" } }}>
         <Grid container spacing={8}>
           <Grid item mobile={12} tablet={6}>
-            <Typography>
+            <Typography align="justify">
               The bond of brotherhood established within the walls of Kappa
               Alpha Order is a bond that will last a lifetime. “KA for Life” is
               what we call it. You will hear that from active and alumni
@@ -21,7 +21,7 @@ function BondOfBrotherhood() {
               man becomes a member of Kappa Alpha Order, he is always a part of
               that brotherhood. When alumni return, no matter how long they have
               been away, they are immediately recognized as part of our
-              brotherhood. 
+              brotherhood.
               <br />
               <br />
               Quoting Thomas Carlyle, the Kappa Alpha Order believes that “the

--- a/pages/values/giving-back.js
+++ b/pages/values/giving-back.js
@@ -9,7 +9,7 @@ function GivingBack() {
       <Container sx={{ padding: { mobile: "2rem", laptop: "2rem 20rem" } }}>
         <Grid container spacing={8}>
           <Grid item mobile={12} tablet={6}>
-            <Typography>
+            <Typography align="justify">
               The brothers of Kappa Alpha Order are dedicated to serving our
               school, our community, and our nation. Members of Beta Alpha
               Chapter offer their time and resources across the Midwest, lending

--- a/pages/values/index.js
+++ b/pages/values/index.js
@@ -9,12 +9,12 @@ function Values() {
       <Banner text="Our Values" />
       <Container sx={{ padding: { mobile: "2rem", laptop: "2rem 20rem" } }}>
         <Grid container spacing={8}>
-          <Grid item mobile={12} tablet={6} >
+          <Grid item mobile={12} tablet={6}>
             <TextSectionHeading>
               <DoubleArrowIcon fontSize="large" color="primary" />
               Reverence
             </TextSectionHeading>
-            <Typography>
+            <Typography align="justify">
               Our founders sought to emulate the ideal Christian gentleman and
               in so doing recognized the importance of having a deep reverence
               for God. Our motto, “Dieu et Les Dames” means “God and the ladies”
@@ -27,7 +27,7 @@ function Values() {
               <DoubleArrowIcon fontSize="large" color="primary" />
               Gentility
             </TextSectionHeading>
-            <Typography>
+            <Typography align="justify">
               The men of Kappa Alpha Order are known as the gentlemen of the
               fraternity world. A KA, through his gentility, should always be
               distinguished by his modern chivalric characteristics.
@@ -38,7 +38,7 @@ function Values() {
               <DoubleArrowIcon fontSize="large" color="primary" />
               Service
             </TextSectionHeading>
-            <Typography>
+            <Typography align="justify">
               At the heart of the code of chivalry and the fabric of KA is
               service to those in need. Through community service, volunteerism
               and commitment to philanthropy, KAs aim to serve those around them
@@ -50,7 +50,7 @@ function Values() {
               <DoubleArrowIcon fontSize="large" color="primary" />
               Leadership
             </TextSectionHeading>
-            <Typography>
+            <Typography align="justify">
               We teach our members to be leaders among men, on campus, in their
               communities, and throughout life. Through bravery and
               self-reliance, KAs strive to lead their lives with honor, and when
@@ -63,7 +63,7 @@ function Values() {
               <DoubleArrowIcon fontSize="large" color="primary" />
               Knowledge
             </TextSectionHeading>
-            <Typography>
+            <Typography align="justify">
               The philosophy of our Order is that the acquisition of knowledge
               and the development of character are the great goals of life. Our
               focus on the cultivation of knowledge manifests itself through
@@ -77,7 +77,7 @@ function Values() {
               <DoubleArrowIcon fontSize="large" color="primary" />
               Perseverance
             </TextSectionHeading>
-            <Typography>
+            <Typography align="justify">
               “Onward” is ever our stance despite the danger and difficulty that
               life often brings. KAs understand that anything in life worth
               attaining will take hard work, dedication, and determination,
@@ -85,12 +85,12 @@ function Values() {
               endeavors of life.
             </Typography>
           </Grid>
-          <Grid item mobile={12} sx={{margin: {desktop:"0rem 12rem" } }}>
+          <Grid item mobile={12} sx={{ margin: { desktop: "0rem 12rem" } }}>
             <TextSectionHeading>
               <DoubleArrowIcon fontSize="large" color="primary" />
               Excellence
             </TextSectionHeading>
-            <Typography>
+            <Typography align="justify">
               Excellence is our aim and “Upward” is the direction that we
               continually strive. No matter the situation or circumstance, KAs
               work to attain excellence and to overcome the temptation to settle

--- a/pages/values/top-5-reasons.js
+++ b/pages/values/top-5-reasons.js
@@ -14,7 +14,7 @@ function TopFiveReasons() {
               <DoubleArrowIcon fontSize="large" color="primary" />
               Brotherhood
             </TextSectionHeading>
-            <Typography>
+            <Typography align="justify">
               Thanks to our size, we are both a big house, and a small house.
               Being a big house means no matter what class you are in, or what
               problems you are dealing with, there is someone in KA who is able
@@ -29,11 +29,11 @@ function TopFiveReasons() {
               <DoubleArrowIcon fontSize="large" color="primary" />
               Academics
             </TextSectionHeading>
-            <Typography>
+            <Typography align="justify">
               We pride ourselves in our academic success. As an organization, we
               have implemented a thorough academic competition which not only
-              helps us to keep track of how we&apos;re all doing, but also provides
-              an extra incentive to do well!
+              helps us to keep track of how we&apos;re all doing, but also
+              provides an extra incentive to do well!
             </Typography>
           </Grid>
           <Grid item mobile={12} tablet={6}>
@@ -41,7 +41,7 @@ function TopFiveReasons() {
               <DoubleArrowIcon fontSize="large" color="primary" />
               Character Development
             </TextSectionHeading>
-            <Typography>
+            <Typography align="justify">
               Fostering a strong work ethic and leadership abilities, joining KA
               has a profound impact on making a good person into a great person.
             </Typography>
@@ -51,18 +51,18 @@ function TopFiveReasons() {
               <DoubleArrowIcon fontSize="large" color="primary" />
               Social Atmosphere
             </TextSectionHeading>
-            <Typography>
+            <Typography align="justify">
               School is hard, and having a social life in a small town can be
               tough. Being a part of KA allows you to take part in socials with
               fraternities, sororities, and other organizations.
             </Typography>
           </Grid>
-          <Grid item mobile={12} sx={{margin: {desktop:"0rem 12rem" } }}>
+          <Grid item mobile={12} sx={{ margin: { desktop: "0rem 12rem" } }}>
             <TextSectionHeading>
               <DoubleArrowIcon fontSize="large" color="primary" />
               Leadership and Networking Opportunities
             </TextSectionHeading>
-            <Typography>
+            <Typography align="justify">
               Joining KA opens a whole new world of opportunities, through our
               10+ committees, our 13 officers, and our High-Performance Teams,
               we have over 30 leadership positions available at any given time,

--- a/utils/form-helpers.js
+++ b/utils/form-helpers.js
@@ -1,0 +1,16 @@
+/**
+ * Click event handler for form submission buttons that scrolls to the first
+ * textfield element with errors present. The presence of errors is determined
+ * by the Yup validation schema passed to the Formik object associated with
+ * said form.
+ * @param formikErrors - Formik errors object
+ * @return void
+ */
+export const scrollToErrors = (formikErrors) => {
+  const errorKeys = Object.keys(formikErrors);
+  if (errorKeys.length > 0) {
+    setTimeout(() => {
+      document.getElementsByName(errorKeys[0])[0].focus();
+    }, 10);
+  }
+};

--- a/utils/subpages.js
+++ b/utils/subpages.js
@@ -13,7 +13,7 @@ export const awardsSubPages = [
 
 export const aboutSubPages = [
   { title: "About Us", link: "/about" },
-  { title: "Academics", link: "/about/academics"},
+  { title: "Academics", link: "/about/academics" },
   { title: "Scholarships", link: "/about/scholarships" },
   { title: "Greek Life", link: "/about/greek-life" },
   { title: "Officers", link: "/about/officers" },
@@ -23,4 +23,9 @@ export const aboutSubPages = [
   },
   { title: "Letter From a KA Parent", link: "/about/letter-from-ka-parent" },
   { title: "Parents FAQ", link: "/about/parents-faq" },
+];
+
+export const alumniSubPages = [
+  { title: "The BAAA Journal", link: "/alumni" },
+  { title: "Alumni Spotlight Recommendation", link: "/alumni/spotlight" },
 ];


### PR DESCRIPTION
Closes #221 
Closes #194 

I have put together an Alumni Spotlight Recommendation form under the Alumni Tab. Upon submission, the website maintainers and the Beta Alpha Alumni email address will receive a copy of said form for review. The form can be found under the Alumni tab subpages when hovering over the Alumni button on desktop, or in the Alumni dropdown in the mobile menu. You can also find it linked within the intro on the Alumni page. 

In addition to the form I did some general clean up on the other forms of the site and made them all consistent with each other. For example I forgot to include a captcha validation check on the Mailing List Sign-up from (among other things).

I justified as much text as I could throughout the site instead of left-aligning (Becca's recommendation 😺). I think it looks much better now! I took care of #194 while I was here, and fixed a console error that was being printed out. It was complaining about how a Typography components was nested inside of another Typography component.